### PR TITLE
Refactor/dbcontext config separation

### DIFF
--- a/Rovio.MatchMaking.Repositories/Data/AppDbContext.cs
+++ b/Rovio.MatchMaking.Repositories/Data/AppDbContext.cs
@@ -13,11 +13,8 @@ namespace Rovio.MatchMaking.Repositories.Data
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
+            modelBuilder.ApplyConfigurationsFromAssembly(typeof(AppDbContext).Assembly);
             base.OnModelCreating(modelBuilder);
-
-            modelBuilder.ApplyConfiguration(new SessionConfiguration());
-            modelBuilder.ApplyConfiguration(new SessionPlayerConfiguration());
-            modelBuilder.ApplyConfiguration(new QueuedPlayerConfiguration());
         }
     }
 }

--- a/Rovio.MatchMaking.Repositories/Data/AppDbContext.cs
+++ b/Rovio.MatchMaking.Repositories/Data/AppDbContext.cs
@@ -14,34 +14,9 @@ namespace Rovio.MatchMaking.Repositories.Data
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);
+
             modelBuilder.ApplyConfiguration(new SessionConfiguration());
-
-
-            modelBuilder.Entity<SessionPlayer>(entity =>
-            {
-                entity.HasKey(e => e.Id); // Primary Key
-
-                entity.Property(e => e.SessionId)
-                      .IsRequired(); // Foreign key to Session
-
-                entity.Property(e => e.PlayerId)
-                      .IsRequired(); // Foreign key to Player
-
-                entity.Property(e => e.Status)
-                      .IsRequired()
-                      .HasDefaultValue("ATTENDED"); // Default Status
-
-                entity.Property(e => e.Score)
-                      .IsRequired()
-                      .HasDefaultValue(0); // Default Score
-/*
-                entity.Property(e => e.CreatedAt)
-                      .HasDefaultValueSql("CURRENT_TIMESTAMP"); // Default creation timestamp
-
-                entity.Property(e => e.UpdatedAt)
-                      .HasDefaultValueSql("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"); // Default updated timestamp
-*/
-            });
+            modelBuilder.ApplyConfiguration(new SessionPlayerConfiguration());
 
             modelBuilder.Entity<QueuedPlayer>()
                 .Property(e => e.Id)

--- a/Rovio.MatchMaking.Repositories/Data/AppDbContext.cs
+++ b/Rovio.MatchMaking.Repositories/Data/AppDbContext.cs
@@ -17,14 +17,7 @@ namespace Rovio.MatchMaking.Repositories.Data
 
             modelBuilder.ApplyConfiguration(new SessionConfiguration());
             modelBuilder.ApplyConfiguration(new SessionPlayerConfiguration());
-
-            modelBuilder.Entity<QueuedPlayer>()
-                .Property(e => e.Id)
-                .HasColumnType("char(36)");
-
-            modelBuilder.Entity<QueuedPlayer>()
-                .Property(e => e.PlayerId)
-                .HasColumnType("char(36)");
+            modelBuilder.ApplyConfiguration(new QueuedPlayerConfiguration());
         }
     }
 }

--- a/Rovio.MatchMaking.Repositories/Data/AppDbContext.cs
+++ b/Rovio.MatchMaking.Repositories/Data/AppDbContext.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Rovio.MatchMaking.Repositories.Data.Configurations;
 
 namespace Rovio.MatchMaking.Repositories.Data
 {
@@ -13,28 +14,7 @@ namespace Rovio.MatchMaking.Repositories.Data
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);
-
-            modelBuilder.Entity<Session>(entity =>
-            {
-                entity.Property(e => e.Id).HasColumnType("char(36)");
-                entity.Property(e => e.LatencyLevel)
-                      .IsRequired()
-                      .HasDefaultValue(1)
-                      .HasAnnotation("SqlServer:Check", "LatencyLevel >= 1");
-
-                entity.Property(e => e.JoinedCount)
-                      .HasDefaultValue(0)
-                      .HasAnnotation("SqlServer:Check", "JoinedCount <= 10");
-/*
-                entity.Property(e => e.CreatedAt)
-                      .HasDefaultValueSql("CURRENT_TIMESTAMP");
-*/
-                entity.Property(e => e.StartsAt)
-                      .IsRequired();
-
-                entity.Property(e => e.EndsAt)
-                      .IsRequired();
-            });
+            modelBuilder.ApplyConfiguration(new SessionConfiguration());
 
 
             modelBuilder.Entity<SessionPlayer>(entity =>

--- a/Rovio.MatchMaking.Repositories/Data/Configurations/QueuedPlayerConfiguration.cs
+++ b/Rovio.MatchMaking.Repositories/Data/Configurations/QueuedPlayerConfiguration.cs
@@ -11,6 +11,7 @@ namespace Rovio.MatchMaking.Repositories.Data.Configurations
                 .HasColumnType("char(36)");
             entity.Property(e => e.PlayerId)
                 .HasColumnType("char(36)");
+            entity.HasKey(e => e.Id); //Primary key 
         }
     }
 }

--- a/Rovio.MatchMaking.Repositories/Data/Configurations/QueuedPlayerConfiguration.cs
+++ b/Rovio.MatchMaking.Repositories/Data/Configurations/QueuedPlayerConfiguration.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Rovio.MatchMaking.Repositories.Data.Configurations
+{
+    class QueuedPlayerConfiguration : IEntityTypeConfiguration<QueuedPlayer>
+    {
+        public void Configure(EntityTypeBuilder<QueuedPlayer> entity)
+        {
+            entity.Property(e => e.Id)
+                .HasColumnType("char(36)");
+            entity.Property(e => e.PlayerId)
+                .HasColumnType("char(36)");
+        }
+    }
+}

--- a/Rovio.MatchMaking.Repositories/Data/Configurations/SessionConfiguration.cs
+++ b/Rovio.MatchMaking.Repositories/Data/Configurations/SessionConfiguration.cs
@@ -22,6 +22,7 @@ namespace Rovio.MatchMaking.Repositories.Data.Configurations
 
             entity.Property(e => e.EndsAt)
                   .IsRequired();
+            entity.HasKey(e => e.Id); //Primary key
         }
     }
 }

--- a/Rovio.MatchMaking.Repositories/Data/Configurations/SessionConfiguration.cs
+++ b/Rovio.MatchMaking.Repositories/Data/Configurations/SessionConfiguration.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Rovio.MatchMaking.Repositories.Data.Configurations
+{
+    class SessionConfiguration : IEntityTypeConfiguration<Session>
+    {
+        public void Configure(EntityTypeBuilder<Session> entity)
+        {
+            entity.Property(e => e.Id).HasColumnType("char(36)");
+            entity.Property(e => e.LatencyLevel)
+                  .IsRequired()
+                  .HasDefaultValue(1)
+                  .HasAnnotation("SqlServer:Check", "LatencyLevel >= 1");
+
+            entity.Property(e => e.JoinedCount)
+                  .HasDefaultValue(0)
+                  .HasAnnotation("SqlServer:Check", "JoinedCount <= 10");
+
+            entity.Property(e => e.StartsAt)
+                  .IsRequired();
+
+            entity.Property(e => e.EndsAt)
+                  .IsRequired();
+        }
+    }
+}

--- a/Rovio.MatchMaking.Repositories/Data/Configurations/SessionPlayerConfiguration.cs
+++ b/Rovio.MatchMaking.Repositories/Data/Configurations/SessionPlayerConfiguration.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Rovio.MatchMaking.Repositories.Data.Configurations
+{
+    class SessionPlayerConfiguration : IEntityTypeConfiguration<SessionPlayer>
+    {
+        public void Configure(EntityTypeBuilder<SessionPlayer> entity)
+        {
+            entity.HasKey(e => e.Id); // Primary Key
+
+            entity.Property(e => e.SessionId)
+                  .IsRequired(); // Foreign key to Session
+
+            entity.Property(e => e.PlayerId)
+                  .IsRequired(); // Foreign key to Player
+
+            entity.Property(e => e.Status)
+                  .IsRequired()
+                  .HasDefaultValue("ATTENDED"); // Default Status
+
+            entity.Property(e => e.Score)
+                  .IsRequired()
+                  .HasDefaultValue(0); 
+        }
+    }
+}


### PR DESCRIPTION
### Summary  
Refactored `AppDbContext` by moving table configurations to dedicated configuration classes, adding explicit primary key definitions, and using `ApplyConfigurationsFromAssembly` for automatic configuration loading.

### Changes  
- Moved entity configurations to separate `IEntityTypeConfiguration<T>` classes  
- Added explicit primary key definitions using `.HasKey(...)`  
- Implemented `ApplyConfigurationsFromAssembly` to automatically load configurations

No schema changes intended.
